### PR TITLE
Fixed memory overrun and swapped parameters DEC upper/lower limits

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/src/EPROMStore.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/EPROMStore.cpp
@@ -6,24 +6,24 @@
 
 #if USE_DUMMY_EEPROM == 1
 
-static uint8_t dummyEepromStorage[32];
+static uint8_t dummyEepromStorage[EPROMStore::STORE_SIZE];
 
-// Initialize the EEPROM object for ESP boards, settign aside 32 bytes for storage
+// Initialize the EEPROM object for ESP boards, setting aside storage
 void EPROMStore::initialize()
 {
-  LOGV1(DEBUG_EEPROM, F("EEPROM[DUMMY]: Startup with 32 bytes"));
-  memset(dummyEepromStorage, sizeof(dummyEepromStorage), 1);
+  LOGV2(DEBUG_EEPROM, F("EEPROM[DUMMY]: Startup with %d bytes"), EPROMStore::STORE_SIZE);
+  memset(dummyEepromStorage, 0, sizeof(dummyEepromStorage));
 }
 
 // Update the given location with the given value
-void EPROMStore::update(int location, uint8_t value)
+void EPROMStore::update(uint8_t location, uint8_t value)
 {
   LOGV3(DEBUG_EEPROM, F("EEPROM[DUMMY]: Writing %x to %d"), value, location);
   dummyEepromStorage[location] = value;
 }
 
 // Read the value at the given location
-uint8_t EPROMStore::read(int location)
+uint8_t EPROMStore::read(uint8_t location)
 {
   uint8_t value;
   value = dummyEepromStorage[location];
@@ -36,12 +36,12 @@ uint8_t EPROMStore::read(int location)
 // Initialize the EEPROM object for ESP boards, settign aside 32 bytes for storage
 void EPROMStore::initialize()
 {
-  LOGV1(DEBUG_EEPROM, F("EEPROM[ESP]: Startup with 32 bytes"));
-  EEPROM.begin(32);
+  LOGV2(DEBUG_EEPROM, F("EEPROM[ESP]: Startup with %d bytes"), EPROMStore::STORE_SIZE);
+  EEPROM.begin(EPROMStore::STORE_SIZE);
 }
 
 // Update the given location with the given value
-void EPROMStore::update(int location, uint8_t value)
+void EPROMStore::update(uint8_t location, uint8_t value)
 {
   LOGV3(DEBUG_EEPROM, F("EEPROM[ESP]: Writing %x to %d"), value, location);
   EEPROM.write(location, value);
@@ -50,7 +50,7 @@ void EPROMStore::update(int location, uint8_t value)
 }
 
 // Read the value at the given location
-uint8_t EPROMStore::read(int location)
+uint8_t EPROMStore::read(uint8_t location)
 {
   uint8_t value;
   value = EEPROM.read(location);
@@ -67,14 +67,14 @@ void EPROMStore::initialize()
 }
 
 // Update the given location with the given value
-void EPROMStore::update(int location, uint8_t value)
+void EPROMStore::update(uint8_t location, uint8_t value)
 {
   LOGV3(DEBUG_EEPROM, F("EEPROM[Uno/Mega]: Writing8 %x to %d"), value, location);
   EEPROM.write(location, value);
 }
 
 // Read the value at the given location
-uint8_t EPROMStore::read(int location)
+uint8_t EPROMStore::read(uint8_t location)
 {
   uint8_t value = EEPROM.read(location);
   LOGV3(DEBUG_EEPROM, F("EEPROM[Uno/Mega]: Read8 %x from %d"), value, location);
@@ -83,41 +83,73 @@ uint8_t EPROMStore::read(int location)
 
 #endif
 
-void EPROMStore::updateInt16(int loByteAddr, int hiByteAddr, int16_t value)
+// Update the given location with the given value
+void EPROMStore::updateUint8(EPROMStore::Key location, uint8_t value)
 {
-  LOGV5(DEBUG_EEPROM, F("EEPROM: Writing16 %x (%d) to %d, %d"), value, value, loByteAddr, hiByteAddr);
-  update(loByteAddr, value & 0x00FF);
-  update(hiByteAddr, (value >> 8) & 0x00FF);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing8 %x (%d) to %d"), value, value, location);
+  update(location, value);
 }
 
-int16_t EPROMStore::readInt16(int loByteAddr, int hiByteAddr)
+// Read the value at the given location
+uint8_t EPROMStore::readUint8(EPROMStore::Key location)
 {
-  uint8_t valLo = EPROMStore::read(loByteAddr);
-  uint8_t valHi = EPROMStore::read(hiByteAddr);
-  uint16_t uValue = (uint16_t)valLo + (uint16_t)valHi * 256;
-  int16_t value = static_cast<int16_t>(uValue);
-  LOGV5(DEBUG_EEPROM, F("EEPROM: Read16 %x (%d) from %d, %d"), value, value, loByteAddr, hiByteAddr);
+  uint8_t value;
+  value = read(location);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Read8 %x (%d) from %d"), value, value, location);
   return value;
 }
 
-void EPROMStore::updateInt32(int lowestByteAddr, int32_t value)
+void EPROMStore::updateInt16(EPROMStore::Key location, int16_t value)
 {
-  LOGV5(DEBUG_EEPROM, F("EEPROM: Writing32 %x (%l) to %d-%d"), value, value, lowestByteAddr, lowestByteAddr + 3);
-  update(lowestByteAddr, value & 0x00FF);
-  update(lowestByteAddr + 1, (value >> 8) & 0x00FF);
-  update(lowestByteAddr + 2, (value >> 16) & 0x00FF);
-  update(lowestByteAddr + 3, (value >> 24) & 0x00FF);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing16 %x (%d) to %d"), value, value, location);
+  update(location, value & 0x00FF);
+  update(location+1, (value >> 8) & 0x00FF);
 }
 
-int32_t EPROMStore::readInt32(int lowestByteAddr)
+int16_t EPROMStore::readInt16(EPROMStore::Key location)
 {
-  uint8_t val1 = EPROMStore::read(lowestByteAddr);
-  uint8_t val2 = EPROMStore::read(lowestByteAddr + 1);
-  uint8_t val3 = EPROMStore::read(lowestByteAddr + 2);
-  uint8_t val4 = EPROMStore::read(lowestByteAddr + 3);
+  uint8_t valLo = EPROMStore::read(location);
+  uint8_t valHi = EPROMStore::read(location+1);
+  uint16_t uValue = (uint16_t)valLo + (uint16_t)valHi * 256;
+  int16_t value = static_cast<int16_t>(uValue);
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Read16 %x (%d) from %d"), value, value, location);
+  return value;
+}
+
+void EPROMStore::updateUint16(EPROMStore::Key location, uint16_t value)
+{
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing16 %x (%d) to %d"), value, value, location);
+  update(location, value & 0x00FF);
+  update(location+1, (value >> 8) & 0x00FF);
+}
+
+uint16_t EPROMStore::readUint16(EPROMStore::Key location)
+{
+  uint8_t valLo = EPROMStore::read(location);
+  uint8_t valHi = EPROMStore::read(location+1);
+  uint16_t value = (uint16_t)valLo + (uint16_t)valHi * 256;
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Read16 %x (%d) from %d"), value, value, location);
+  return value;
+}
+
+void EPROMStore::updateInt32(EPROMStore::Key location, int32_t value)
+{
+  LOGV4(DEBUG_EEPROM, F("EEPROM: Writing32 %x (%l) to %d"), value, value, location);
+  update(location, value & 0x00FF);
+  update(location + 1, (value >> 8) & 0x00FF);
+  update(location + 2, (value >> 16) & 0x00FF);
+  update(location + 3, (value >> 24) & 0x00FF);
+}
+
+int32_t EPROMStore::readInt32(EPROMStore::Key location)
+{
+  uint8_t val1 = EPROMStore::read(location);
+  uint8_t val2 = EPROMStore::read(location + 1);
+  uint8_t val3 = EPROMStore::read(location + 2);
+  uint8_t val4 = EPROMStore::read(location + 3);
   LOGV5(DEBUG_EEPROM, F("EEPROM: Read32 read these bytes: %x %x %x %x"), val1, val2, val3, val4);
   uint32_t uValue = (uint32_t)val1 + (uint32_t)val2 * 256 + (uint32_t)val3 * 256 * 256 + (uint32_t)val4 * 256 * 256 * 256;
   int32_t value = static_cast<int32_t>(uValue);
-  LOGV4(DEBUG_EEPROM, F("EEPROM: Read32 which is %l from %d-%d"), value, lowestByteAddr, lowestByteAddr + 3);
+  LOGV3(DEBUG_EEPROM, F("EEPROM: Read32 which is %l from %d"), value, location);
   return value;
 }

--- a/Software/Arduino code/OpenAstroTracker/src/EPROMStore.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/EPROMStore.hpp
@@ -9,15 +9,44 @@ class EPROMStore {
 
 public:
 
+  enum Key { 
+    SPEED_FACTOR_LOW=0, SPEED_FACTOR_HIGH=3,  // Split as two discontinuous Uint8
+    HA_HOUR=1, HA_MINUTE=2, // Both Uint8
+    FLAGS=4,  // Uint8
+    MAGIC_MARKER=5, // Uint8
+    MAGIC_MARKER_AND_FLAGS=4,   // Alias for Uint16 access
+    RA_STEPS_DEGREE=6, _RA_STEPS_DEGREE_1=7,    // Int16
+    DEC_STEPS_DEGREE=8, _DEC_STEPS_DEGREE_1=9,  // Int16
+    BACKLASH_STEPS=10, _BACKLASH_STEPS_1=11,    // Int16
+    LATITUDE=12, _LATITUDE_1=13,    // Int16
+    LONGITUDE=14, _LONGITUDE_1=13,  // Int16
+    LCD_BRIGHTNESS=16, // Uint8
+    PITCH_OFFSET=17, _PITCH_OFFSET_1=18,  // Uint16
+    ROLL_OFFSET=19, _ROLL_OFFSET_1=20,    // Uint16
+    EXTENDED_FLAGS=21, _EXTENDED_FLAGS_1=22,  // Uint16
+    RA_PARKING_POS=23, _RA_PARKING_POS_1, _RA_PARKING_POS_2, _RA_PARKING_POS_3,     // Int32
+    DEC_PARKING_POS=27, _DEC_PARKING_POS_1, _DEC_PARKING_POS_2, _DEC_PARKING_POS_3, // Int32
+    DEC_LOWER_LIMIT=31, _DEC_LOWER_LIMIT_1, _DEC_LOWER_LIMIT_2, _DEC_LOWER_LIMIT_3, // Int32
+    DEC_UPPER_LIMIT=35, _DEC_UPPER_LIMIT_1, _DEC_UPPER_LIMIT_2, _DEC_UPPER_LIMIT_3, // Int32
+    STORE_SIZE=64   
+  };
+
   static void initialize();
 
-  static void update(int location, uint8_t value);
-  static uint8_t read(int location);
+  static void updateUint8(Key location, uint8_t value);
+  static uint8_t readUint8(Key location);
 
-  static void updateInt16(int loByteAddr, int hiByteAddr, int16_t value);
-  static int16_t readInt16(int loByteAddr, int hiByteAddr);
+  static void updateUint16(Key location, uint16_t value);
+  static uint16_t readUint16(Key location);
 
-  static void updateInt32(int lowestByteAddr, int32_t value);
-  static int32_t readInt32(int lowestByteAddr);
+  static void updateInt16(Key location, int16_t value);
+  static int16_t readInt16(Key location);
+
+  static void updateInt32(Key location, int32_t value);
+  static int32_t readInt32(Key location);
+
+private:
+  static void update(uint8_t location, uint8_t value);
+  static uint8_t read(uint8_t location);
 };
 

--- a/Software/Arduino code/OpenAstroTracker/src/LcdMenu.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/LcdMenu.cpp
@@ -60,7 +60,7 @@ void LcdMenu::startup()
   _lcd.setBacklight(RED);
   #endif
 
-  _brightness = EPROMStore::read(16);
+  _brightness = EPROMStore::readUint8(EPROMStore::LCD_BRIGHTNESS);
   LOGV2(DEBUG_INFO, F("LCD: Brightness from EEPROM is %d"), _brightness);
   // pinMode(10, OUTPUT);
   // analogWrite(10, _brightness);
@@ -142,7 +142,7 @@ void LcdMenu::setBacklightBrightness(int level, bool persist)
   if (persist)
   {
     // LOGV2(DEBUG_INFO, F("LCD: Saving %d as brightness"), (_brightness & 0x00FF));
-    EPROMStore::update(EPROMStore::LCD_BRIGHTNESS, (byte)(_brightness & 0x00FF));
+    EPROMStore::updateUint8(EPROMStore::LCD_BRIGHTNESS, (byte)(_brightness & 0x00FF));
   }
 }
 

--- a/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/b_setup.hpp
@@ -145,17 +145,17 @@ void setup() {
   // Calling the LCD startup here, I2C can't be found if called earlier
   #if DISPLAY_TYPE > 0
     lcdMenu.startup();
-  #endif
+#endif
 
-  LOGV1(DEBUG_ANY, F("Finishing boot..."));
-  // Show a splash screen
-  lcdMenu.setCursor(0, 0);
-  lcdMenu.printMenu("OpenAstroTracker");
-  lcdMenu.setCursor(5, 1);
-  lcdMenu.printMenu(VERSION);
+    LOGV1(DEBUG_ANY, F("Finishing boot..."));
+    // Show a splash screen
+    lcdMenu.setCursor(0, 0);
+    lcdMenu.printMenu("OpenAstroTracker");
+    lcdMenu.setCursor(5, 1);
+    lcdMenu.printMenu(VERSION);
 
-  #if DISPLAY_TYPE > 0
-    // Check for EEPROM reset (Button down during boot)
+#if DISPLAY_TYPE > 0
+      // Check for EEPROM reset (Button down during boot)
     if (lcdButtons.currentState() == btnDOWN){
       LOGV1(DEBUG_INFO, F("Erasing configuration in EEPROM!"));
       mount.clearConfiguration();
@@ -167,7 +167,7 @@ void setup() {
       }
     }
 
-  unsigned long now = millis();
+    unsigned long now = millis();
   #endif
   
   LOGV2(DEBUG_ANY, F("Hardware: %s"), mount.getMountHardwareInfo().c_str());
@@ -227,7 +227,7 @@ void setup() {
   mount.readConfiguration();
   
   // Read other persisted values and set in mount
-  DayTime haTime = DayTime(EPROMStore::read(1), EPROMStore::read(2), 0);
+  DayTime haTime = DayTime(EPROMStore::readUint8(EPROMStore::HA_HOUR), EPROMStore::readUint8(EPROMStore::HA_MINUTE), 0);
 
   LOGV2(DEBUG_INFO, "SpeedCal: %s", String(mount.getSpeedCalibration(), 5).c_str());
   LOGV2(DEBUG_INFO, "TRKSpeed: %s", String(mount.getSpeed(TRACKING), 5).c_str());
@@ -244,7 +244,7 @@ void setup() {
   LOGV1(DEBUG_ANY, F("Start Tracking..."));
   mount.startSlewing(TRACKING);
 
-  #if DISPLAY_TYPE > 0
+#if DISPLAY_TYPE > 0
     LOGV1(DEBUG_ANY, F("Setup menu system..."));
 
     // Create the LCD top-level menu items

--- a/Software/Arduino code/OpenAstroTracker/src/c72_menuHA.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/c72_menuHA.hpp
@@ -35,8 +35,8 @@ bool processHAKeys() {
       break;
 
       case btnSELECT: {
-        EPROMStore::update(1, mount.HA().getHours());
-        EPROMStore::update(2, mount.HA().getMinutes());
+        EPROMStore::updateUint8(EPROMStore::HA_HOUR, mount.HA().getHours());
+        EPROMStore::updateUint8(EPROMStore::HA_MINUTE, mount.HA().getMinutes());
         lcdMenu.printMenu("Stored.");
         mount.delay(500);
 


### PR DESCRIPTION
Replaced explicit numeric locations with named locations (keys) as part of identifying and fixing two defects: 

- only 32 bytes being allocated but >32 bytes being accessed in NVM
- DEC_LOWER_LIMIT & DEC_UPPER_LIMIT values swapped on read from NVM.

Added specializations for int16 and uint16 types.
TODO: Ideally EPROMStore would manage all scaling for storage and remove decoupled store/load implementation in Mount - too hard too maintain.
TODO: On ESP32 commit() is called after every byte written - should really be after complete access to make update atomic