### PR TITLE
Verify presence, reduce bandwidth, decorrelated measurements

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/src/Gyro.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Gyro.cpp
@@ -8,30 +8,34 @@
 
 const int MPU = 0x68; // I2C address of the MPU6050 accelerometer
 
-int16_t Gyro::AcX, Gyro::AcY, Gyro::AcZ;
-int16_t Gyro::AcXOffset, Gyro::AcYOffset, Gyro::AcZOffset;
+bool Gyro::isPresent(false);
 
 void Gyro::startup()
 {
     // Initialize interface to the MPU6050
     LOGV1(DEBUG_INFO, F("GYRO:: Starting"));
     Wire.begin();
+
     Wire.beginTransmission(MPU);
-    Wire.write(0x6B);
-    Wire.write(0);
+    Wire.write(0x75);   // WHO_AM_I
+    Wire.endTransmission(true);
+    Wire.requestFrom(MPU, 1, 1);
+    byte id = (Wire.read() >> 1) & 0x3F;    
+    isPresent = (id == 0x34);
+    if (!isPresent) {
+        LOGV1(DEBUG_INFO, F("GYRO:: Not found!"));
+        return;
+    }
+
+    Wire.beginTransmission(MPU);
+    Wire.write(0x6B);   // PWR_MGMT_1
+    Wire.write(0);      // Disable sleep, 8 MHz clock
+    Wire.endTransmission(true);
+    Wire.beginTransmission(MPU);
+    Wire.write(0x1A);   // CONFIG
+    Wire.write(6);      // 5Hz bandwidth
     Wire.endTransmission(true);
 
-    // read the values 100 times for them to stabilize
-    for (int i = 0; i < 100; i++)
-    {
-        Wire.beginTransmission(MPU);
-        Wire.write(0x3B); // Start with register 0x3B (ACCEL_XOUT_H)
-        Wire.endTransmission(false);
-        Wire.requestFrom(MPU, 6, 1);       // Read 6 registers total, each axis value is stored in 2 registers
-        AcX = Wire.read() << 8 | Wire.read(); // X-axis value
-        AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
-        AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
-    }
     LOGV1(DEBUG_INFO, F("GYRO:: Started"));
 }
 
@@ -48,20 +52,25 @@ angle_t Gyro::getCurrentAngles()
     struct angle_t result;
     result.pitchAngle = 0;
     result.rollAngle = 0;
+    if (!isPresent)
+        return result;     // Gyro is not available
+
     for (int i = 0; i < windowSize; i++)
     {
         Wire.beginTransmission(MPU);
         Wire.write(0x3B); // Start with register 0x3B (ACCEL_XOUT_H)
         Wire.endTransmission(false);
         Wire.requestFrom(MPU, 6, 1);       // Read 6 registers total, each axis value is stored in 2 registers
-        AcX = Wire.read() << 8 | Wire.read(); // X-axis value
-        AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
-        AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
+        int16_t AcX = Wire.read() << 8 | Wire.read(); // X-axis value
+        int16_t AcY = Wire.read() << 8 | Wire.read(); // Y-axis value
+        int16_t AcZ = Wire.read() << 8 | Wire.read(); // Z-axis value
 
         // Calculating the Pitch angle (rotation around Y-axis)
         result.pitchAngle += ((atan(-1 * AcX / sqrt(pow(AcY, 2) + pow(AcZ, 2))) * 180.0 / PI) * 2.0) / 2.0;
         // Calculating the Roll angle (rotation around X-axis)
         result.rollAngle += ((atan(-1 * AcY / sqrt(pow(AcX, 2) + pow(AcZ, 2))) * 180.0 / PI) * 2.0) / 2.0;
+
+        delay(10);  // Decorrelate measurements
     }
 
     result.pitchAngle /= windowSize;
@@ -76,6 +85,9 @@ angle_t Gyro::getCurrentAngles()
 
 float Gyro::getCurrentTemperature()
 {
+    if (!isPresent)
+        return 99.9;     // Gyro is not available
+
     // Read the temperature data
     float result = 0.0;
     int16_t tempValue;

--- a/Software/Arduino code/OpenAstroTracker/src/Gyro.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Gyro.hpp
@@ -3,7 +3,7 @@
 #include "../Configuration_adv.hpp"
 
 #if USE_GYRO_LEVEL == 1
-struct angle_t { float pitchAngle; float rollAngle; };
+struct angle_t { float pitchAngle = 0; float rollAngle = 0; };
 
 class Gyro 
 {
@@ -14,7 +14,6 @@ public:
   static float getCurrentTemperature();
   
 private:
-  static int16_t AcX, AcY, AcZ;
-  static int16_t AcXOffset, AcYOffset, AcZOffset;
+  static bool isPresent;  // True if gyro correctly detected on startup
 };
 #endif


### PR DESCRIPTION
Added check for presence of gyro sensor and return safe values if not present.
Reduced bandwidth, and added delay between consecutive samples to ensure decorrelated samples for averaging process. This makes for a much smoother levelling process.
Eliminated unnecessary "warmup" during startup().
Confirmed as working on ESP32.