### PR TITLE
Consolidated and documented stepper servicing

### DIFF
--- a/Software/Arduino code/OpenAstroTracker/src/Mount.cpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Mount.cpp
@@ -1,5 +1,3 @@
-#include "InterruptCallback.hpp"
-
 #include "LcdMenu.hpp"
 #include "Mount.hpp"
 #include "Utility.hpp"
@@ -98,15 +96,6 @@ const char* formatStringsRA[] = {
   "%02d%02d%02d",           // Compact
 };
 
-/////////////////////////////////
-// This is the callback function for the timer interrupt. It does very minimal work,
-// only stepping the stepper motors as needed.
-/////////////////////////////////
-void mountLoop(void* payload) {
-  Mount* mount = reinterpret_cast<Mount*>(payload);
-  mount->interruptLoop();
-}
-
 Mount* Mount::_instance = nullptr;
 Mount Mount::instance() { return *_instance; };
 
@@ -163,23 +152,6 @@ Mount::Mount(int stepsPerRADegree, int stepsPerDECDegree, LcdMenu* lcdMenu) {
   _pitchCalibrationAngle = 0;
   _rollCalibrationAngle = 0;
   #endif
-}
-
-/////////////////////////////////
-//
-// startTimerInterrupts
-//
-/////////////////////////////////
-void Mount::startTimerInterrupts()
-{
-#ifndef ESPBOARD
-  // 2 kHz updates (higher frequency interferes with serial communications and complete messes up OATControl communications)
-  if (!InterruptCallback::setInterval(0.5f, mountLoop, this))
-  {
-    LOGV1(DEBUG_MOUNT, F("Mount:: CANNOT setup interrupt timer!"));
-  }
-#endif // !ESPBOARD
-
 }
 
 /////////////////////////////////

--- a/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
+++ b/Software/Arduino code/OpenAstroTracker/src/Mount.hpp
@@ -267,9 +267,6 @@ public:
   // Get the number of steps to use for backlash correction
   int getBacklashCorrection();
   
-  // Called when startup is complete and the mount needs to start updating steppers.
-  void startTimerInterrupts();
-
   // Read the saved configuration from persistent storage
   void readConfiguration();
 


### PR DESCRIPTION
Consolidated ESP32, ATMega, and RUN_STEPPERS_IN_MAIN_LOOP into b_setup.hpp.
Added documentation for all 3 methods of servicing steppers.
Some slight reordering of menu system construction in setup() to reduce number of conditional sections